### PR TITLE
Send DescribeConfigsRequest v1 when possible

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -442,6 +442,10 @@ func (ca *clusterAdmin) DescribeConfig(resource ConfigResource) ([]ConfigEntry, 
 		Resources: resources,
 	}
 
+	if ca.conf.Version.IsAtLeast(V1_1_1_0) {
+		request.Version = 1
+	}
+
 	b, err := ca.Controller()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
DescribeConfigsRequest v1 opts the caller into the v1 response format, described in [KIP-226](https://cwiki.apache.org/confluence/display/KAFKA/KIP-226+-+Dynamic+Broker+Configuration) which includes various improvements, including replacing the `is_default` field with the more useful `config_source` field, and optionally including information about synonyms.